### PR TITLE
Update clamav database before running rpminspect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN dnf -y install \
     python3-pyyaml \
     koji \
     git \
+    clamav-update \
     && dnf clean all
 
 COPY rpminspect_runner.sh generate_tmt.sh /usr/local/bin/

--- a/rpminspect_runner.sh
+++ b/rpminspect_runner.sh
@@ -175,6 +175,12 @@ if [ "${output_format}" == "text" ]; then
     echo "======================================== Test Output ========================================"
 fi
 
+# Update the clamav database
+freshclam
+if [ $? -ne 0 ]; then
+    echo "ERROR: Updating the ClamAV database failed."
+fi
+
 rpminspect -c ${config} \
            ${output_format:+--format=$output_format} \
            --arches x86_64,noarch,src \


### PR DESCRIPTION
If running the virus scan in rpminspect, it will throw an error like this:

LibClamAV Warning: **************************************************
LibClamAV Warning: ***  The virus database is older than 7 days!  ***
LibClamAV Warning: ***   Please update it as soon as possible.    ***
LibClamAV Warning: **************************************************

Running freshclam, as we do in GHA here, solves this error: 
https://github.com/rpminspect/rpminspect/blob/master/osdeps/fedora/post.sh#L29

I'm guessing we'll need to make a similar fix in downstream in the Dockerfile, though I know you are working on an update to this script so you tell me the best way to proceed. :) @msrb 