### PR TITLE
Run all inspections at once and cache results

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ RUN dnf -y install \
     git \
     && dnf clean all
 
-COPY rpminspect_runner.sh generate_tmt.sh /usr/local/bin/
+COPY *.sh rpminspect_json2text.py /usr/local/bin/
 
 WORKDIR ${RPMINSPECT_WORKDIR}

--- a/rpminspect_get_local_config.sh
+++ b/rpminspect_get_local_config.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Usage:
+# ./rpminspect_get_local_config.sh $AFTER_BUILD
+#
+# The script recognizes following environment variables:
+# KOJI_BIN - path where to find "koji" binary
+# CONFIG_BRANCH - git branch where to look for the rpminspect.yaml
+
+
+config_branch="${CONFIG_BRANCH}"
+koji_bin="${KOJI_BIN:-/usr/bin/koji}"
+
+after_build="${1}"
+
+repo_ref=$(${koji_bin} buildinfo ${after_build} | grep "^Source: " | awk '{ print $2 }' | sed 's|^git+||')
+repo_url=$(echo ${repo_ref} | awk -F'#' '{ print $1 }')
+commit_ref=$(echo ${repo_ref} | awk -F'#' '{ print $2 }')
+
+# obtain the package-specific config file
+if [ ! -f "rpminspect.yaml" ]; then
+    (
+        tmp_dir=$(mktemp -d -t rpminspect-XXXXXXXXXX)
+
+        pushd ${tmp_dir}
+            git init
+            git remote add origin ${repo_url}
+
+            if [ -n "${config_branch}" ]; then
+                # we take the config from the HEAD of the given branch
+                git fetch origin "refs/heads/${config_branch}" --depth 1
+                git checkout ${config_branch}
+            else
+                # we take the config from the build commit
+                git fetch origin
+                git checkout ${commit_ref}
+            fi
+        popd
+
+        # and finally, copy the config to the current directory;
+        # or create an empty one if missing in the repository
+        cp ${tmp_dir}/rpminspect.yaml . || echo "inspections: {}" > rpminspect.yaml
+        rm -Rf "${tmp_dir}"
+    ) >> clone.log 2>&1
+fi

--- a/rpminspect_json2text.py
+++ b/rpminspect_json2text.py
@@ -1,0 +1,117 @@
+#!/usr/bin/python3
+
+import json
+import argparse
+from pathlib import Path
+
+
+# JSON output uses slightly different names
+# for some of the inspections.
+# FIXME: get rid of this once this is fixed upstream:
+# https://github.com/rpminspect/rpminspect/issues/397
+json2text_mapping = {
+    'empty-payload': 'emptyrpm',
+    'lost-payload': 'lostpayload',
+    'header-metadata': 'metadata',
+    'man-pages': 'manpage',
+    'xml-files': 'xml',
+    'elf-object-properties': 'elf',
+    'desktop-entry-files': 'desktop',
+    'dist-tag': 'disttag',
+    'spec-file-name': 'specname',
+    'java-bytecode': 'javabytecode',
+    'changed-files': 'changedfiles',
+    'moved-files': 'movedfiles',
+    'removed-files': 'removedfiles',
+    'added-files': 'addedfiles',
+    'shell-syntax': 'shellsyntax',
+    'dso-deps': 'dsodeps',
+    'kernel-modules': 'kmod',
+    'architectures': 'arch',
+    'path-migration': 'pathmigration',
+    'bad-functions': 'badfuncs'
+}
+
+
+def process_results(results_json, results_dir):
+    """Process rpminspect JSON and split results into individual text files.
+
+    One inspection result per file. Also store the outcome (pass/fail)
+    in a separate file.
+    """
+    with open(results_json) as f:
+        inspections = json.load(f)
+
+        inspections.pop('rpminspect')
+
+        # Add default "skipped" inspection that will be returned when there are no results
+        inspections['skipped'] = [
+            {
+                'message': 'This inspection did not run.',
+                'result': 'INFO'
+            }
+        ]
+
+        for inspection_json_name, inspection in inspections.items():
+            inspection_name = json2text_mapping.get(inspection_json_name) or inspection_json_name
+
+            result_str = ''
+
+            result_str += f'\n{inspection_name}:\n'
+            result_str += '-' * (len(inspection_name) + 1)
+            result_str += '\n\n'
+
+            outcomes = set()
+            for index, result in enumerate(inspection):
+
+                message = result.get('message', '')
+                if message:
+                    result_str += f"{index+1}) {message}\n\n"
+
+                outcome = result.get('result', '')
+                if outcome:
+                    result_str += f"Result: {outcome}\n"
+                    outcomes.add(outcome)
+
+                waiver_auth = result.get('waiver authorization', '')
+                if waiver_auth:
+                    result_str += f"Waiver Authorization: {waiver_auth}\n"
+
+                details = result.get('details', '')
+                if details:
+                    result_str += f"\nDetails:\n{details}\n"
+
+                remedy = result.get('remedy', '')
+                if remedy:
+                    result_str += f"\nSuggested Remedy:\n{remedy}\n"
+
+                result_str += '\n\n'
+
+            # remove all good outcomes
+            outcomes.discard('OK')
+            outcomes.discard('INFO')
+            outcomes.discard('WAIVED')
+
+            status = 0  # success
+            # the outcomes set should be empty now,
+            # if all went well
+            if outcomes:
+                # nope, there are some failures or unknown outcomes...
+                # let's fail the test
+                status = 1  # failure
+
+            result_path = Path(results_dir) / Path(inspection_name + '_result')
+            with open(result_path, 'w') as output_f:
+                output_f.write(result_str)
+
+            status_path = Path(results_dir) / Path(inspection_name + '_status')
+            with open(status_path, 'w') as output_f:
+                output_f.write(str(status))
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('resultsdir', help='directory where to store results')
+    parser.add_argument('rpminspectjson', help='JSON output from rpminspect')
+    args = parser.parse_args()
+    process_results(args.rpminspectjson, args.resultsdir)

--- a/rpminspect_runner.sh
+++ b/rpminspect_runner.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Usage:
-# ./rpminspect_runner.sh $TASK_ID $PREVIOUS_TAG [ $TEST_NAME ]
+# ./rpminspect_runner.sh $TASK_ID $PREVIOUS_TAG $TEST_NAME
 #
 # The script recognizes following environment variables:
 # RPMINSPECT_CONFIG - path to the rpminspect config file
@@ -9,9 +9,6 @@
 # PREVIOUS_TAG - koji tag where to look for previous builds
 # DEFAULT_RELEASE_STRING - release string to use in case builds
 #                          don't have them (e.g.: missing ".fc34")
-# OUTPUT_FORMAT - rpminspect output format (text, json, xunit)
-# OUTPUT_FILE - redirect the standard output into a file
-# CONFIG_BRANCH - branch where to look for the package-specific config file
 # RPMINSPECT_WORKDIR - workdir where to cache downloaded builds
 # KOJI_BIN - path where to find "koji" binary
 # ARCHES - a comma-separated list of architectures to test (e.g.: x86_64,noarch,src)
@@ -52,8 +49,6 @@ test_name=${3}
 # rpminspect doesn't know which test configuration to use
 default_release_string=${DEFAULT_RELEASE_STRING}
 
-output_format=${OUTPUT_FORMAT:-text}
-
 profile_name=${RPMINSPECT_PROFILE_NAME}
 
 arches=${ARCHES}
@@ -66,6 +61,24 @@ get_name_from_nvr() {
     # Pfff... close your eyes here...
     name=$(echo $nvr | sed 's/^\(.*\)-\([^-]\{1,\}\)-\([^-]\{1,\}\)$/\1/')
     echo -n ${name}
+}
+
+quit_if_disabled() {
+    # Quit the script if the inspection is disabled in config/profile file.
+    # Params:
+    # $1: inspection name
+    local inspection_name=$1
+
+    is_enabled=$(python3 -c "\
+import yaml; \
+import sys; \
+is_enabled = yaml.safe_load(open(sys.argv[1])).get('inspections', {}).get(sys.argv[2], True); \
+print('yes', end='') if is_enabled else print('no', end='')" "effective_rpminspect.yaml" "${inspection_name}")
+    if [ "${is_enabled}" == "no" ]; then
+        echo
+        echo "This inspection is disabled."
+        exit 0
+    fi
 }
 
 get_after_build() {
@@ -101,109 +114,76 @@ get_before_build() {
     echo -n ${before_build}
 }
 
-after_build=$(get_after_build $task_id)
-before_build=$(get_before_build $after_build $previous_tag)
-
-
-repo_ref=$(${koji_bin} buildinfo ${after_build} | grep "^Source: " | awk '{ print $2 }' | sed 's|^git+||')
-repo_url=$(echo ${repo_ref} | awk -F'#' '{ print $1 }')
-commit_ref=$(echo ${repo_ref} | awk -F'#' '{ print $2 }')
-# obtain a package-specific config file
-if [ ! -f "rpminspect.yaml" ]; then
-    (
-        tmp_dir=$(mktemp -d -t rpminspect-XXXXXXXXXX)
-
-        pushd ${tmp_dir}
-            git init
-            git remote add origin ${repo_url}
-
-            if [ -n "$CONFIG_BRANCH" ]; then
-                # we take the config from the HEAD of the given branch
-                git fetch origin "refs/heads/${CONFIG_BRANCH}" --depth 1
-                git checkout ${CONFIG_BRANCH}
-            else
-                # we take the config from the build commit
-                git fetch origin
-                git checkout ${commit_ref}
-            fi
-        popd
-
-        # and finally, copy the config to the current directory;
-        # or create an empty one if missing in the repository
-        cp ${tmp_dir}/rpminspect.yaml . || echo "inspections: {}" > rpminspect.yaml
-        rm -Rf "${tmp_dir}"
-    ) >> clone.log 2>&1
-fi
-
-if [ -n "$test_name" ]; then
-    # get the effective config file
-    # https://github.com/rpminspect/rpminspect/issues/306
-    rpminspect ${debug:+-v} -c ${config} ${profile_name:+--profile=$profile_name} -D > effective_rpminspect.yaml || :
-
-    is_enabled=$(python3 -c "\
-import yaml; \
-import sys; \
-is_enabled = yaml.safe_load(open(sys.argv[1])).get('inspections', {}).get(sys.argv[2], True); \
-print('yes', end='') if is_enabled else print('no', end='')" "effective_rpminspect.yaml" "${test_name}")
-    if [ "${is_enabled}" == "no" ]; then
-        echo "\"${test_name}\" inspection is disabled in the package-specific configuration file: ${repo_url} branch/ref: ${CONFIG_BRANCH:-$commit_ref}"
-        echo "Skipping..."
-        exit 0
-    fi
-fi
-
 workdir="${RPMINSPECT_WORKDIR:-/var/tmp/rpminspect/}${task_id}-${before_build}"
-downloaded_file=${workdir}/downloaded
+results_cache_dir="${RPMINSPECT_WORKDIR:-/var/tmp/rpminspect/}results_cache"
+results_cached_file="${RPMINSPECT_WORKDIR:-/var/tmp/rpminspect/}cached"
 
 mkdir -p ${workdir}
+mkdir -p "${results_cache_dir}"
 
-rpminspect_tmp_dir="/var/tmp/rpminspect/"
-# Print information about disk space
-if [ "$debug" == "on" ]; then
-    df -h "${workdir}"
-    du -h -s "${workdir}" "${rpminspect_tmp_dir}" || :
-fi
 
-# Download and cache packages, if not downloaded already
-if [ ! -f ${downloaded_file} ]; then
-    rpminspect ${debug:+-v} -c ${config} ${arches:+--arches=$arches} -w ${workdir} -f ${after_build}
-    # Download also the before build, if it exists and is not the same as the after build
-    if [ -n "${before_build}" ] && [ "${before_build}" != "${after_build}" ]; then
-        rpminspect ${debug:+-v} -c ${config} ${arches:+--arches=$arches} -w ${workdir} -f ${before_build}
+# cache results — the following section should run in CI only once
+if [ ! -f "${results_cached_file}" ]; then
+    after_build=$(get_after_build $task_id)
+    before_build=$(get_before_build $after_build $previous_tag)
+
+    echo -n "${after_build}" > "${results_cache_dir}/after_build"
+    echo -n "${before_build}" > "${results_cache_dir}/before_build"
+
+    if [ ! -f "effective_rpminspect.yaml" ]; then
+        # Get the effective config file
+        rpminspect -c ${config} \
+                ${debug:+-v} \
+                ${profile_name:+--profile=$profile_name} \
+                -D > effective_rpminspect.yaml || :
     fi
-    touch ${downloaded_file}
+
+    rpminspect_get_local_config.sh "${after_build}" ""
+
+    # Run all inspections and cache results
+    rpminspect -c ${config} \
+            ${debug:+-v} \
+            --format=json \
+            ${arches:+--arches=$arches} \
+            ${default_release_string:+--release=$default_release_string} \
+            ${profile_name:+--profile=$profile_name} \
+            ${before_build} \
+            ${after_build} \
+            > results.json 2> stderr.log || :
+
+    # Convert JSON to text and store results of each inspection to a separate file
+    rpminspect_json2text.py "${results_cache_dir}" results.json
+    touch "${results_cached_file}"
 fi
 
-# Print information about disk space
-if [ "$debug" == "on" ]; then
-    df -h "${workdir}"
-    du -h -s "${workdir}" "${rpminspect_tmp_dir}" || :
+after_build=$(cat "${results_cache_dir}/after_build")
+before_build=$(cat "${results_cache_dir}/before_build")
+
+# Get description for current inspection
+rpminspect -l -v | awk -v RS= -v ORS='\n\n' "/    ${test_name}\n/" | sed -e 's/^[ \t]*//' | tail -n +2 > "${results_cache_dir}/${test_name}_description"
+
+echo "rpminspect version: ${RPMINSPECT_VERSION} (with data package: ${RPMINSPECT_DATA_VERSION})"
+echo "rpminspect profile: ${profile_name:-none}"
+echo "new build: ${after_build}"
+if [ -z "${before_build}" ]; then
+    echo "old build: not found (in ${previous_tag} $(basename ${koji_bin}) tag)"
+else
+    echo "old build: ${before_build} (found in ${previous_tag} $(basename ${koji_bin}) tag)"
+fi
+echo
+echo "Test description:"
+cat "${results_cache_dir}/${test_name}_description"
+echo "======================================== Test Output ========================================"
+
+quit_if_disabled "${test_name}"
+
+if [ -f "${results_cache_dir}/${test_name}_result" ]; then
+    cat "${results_cache_dir}/${test_name}_result"
+    rc=$(cat "${results_cache_dir}/${test_name}_status")
+else
+    # This inspection did not run (modularity inspection?)
+    cat "${results_cache_dir}/skipped_result"
+    rc=0  # success
 fi
 
-# Print nicer output if the output format is "text"
-if [ "${output_format}" == "text" ]; then
-    if [ -z "${before_build}" ]; then
-        echo "Running rpminspect on ${after_build}. No older builds were found in the \"${previous_tag}\" $(basename ${koji_bin}) tag."
-    else
-        echo "Comparing ${after_build} with the older ${before_build} found in the \"${previous_tag}\" $(basename ${koji_bin}) tag."
-    fi
-    echo
-    echo "Test description:"
-
-    test_description=$(rpminspect -l -v | awk -v RS= -v ORS='\n\n' "/    ${test_name}\n/")
-
-    echo "${test_description}"
-    echo
-    echo "======================================== Test Output ========================================"
-fi
-
-rpminspect -c ${config} \
-           ${debug:+-v} \
-           ${output_format:+--format=$output_format} \
-           ${arches:+--arches=$arches} \
-           ${default_release_string:+--release=$default_release_string} \
-           ${profile_name:+--profile=$profile_name} \
-           ${test_name:+--tests=$test_name} \
-           ${workdir}/${before_build} \
-           ${workdir}/${after_build} \
-           > ${OUTPUT_FILE:-/dev/stdout}
+exit $((rc))


### PR DESCRIPTION
This fundamentally changes how we run rpminspect and how we treat its
results, so the patch is huge...

Previous approach when we were running rpminspect separately for each
inspection was problematic as rpminspect was unpacking sources on every
invocation. Which was perfectly fine in 99% of cases, but some builds
can be 100+ gigs unpackaged... And unpacking is CPU-bound operation, and
machines in CI sometimes don't have enough... so CI would kill
rpminspect because it was taking too long.. etc. You get the point.

So here, we are going to run rpminspect only once, and then return cached
results when asked for specific inspection.

This is also getting super-painful to maintain so it's probably time to
rewrite the whole script in Python.