### PR TITLE
Update data package before running rpminspect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,6 @@ LABEL description="rpminspect for fedora-ci"
 
 # https://copr.fedorainfracloud.org/coprs/dcantrell/rpminspect/
 ENV RPMINSPECT_VERSION=1.6-0.1.202107121853git.fc35
-ENV RPMINSPECT_DATA_VERSION=1:1.5-0.1.202108041945git.fc35
 
 ENV RPMINSPECT_WORKDIR=/workdir/
 ENV HOME=${RPMINSPECT_WORKDIR}
@@ -18,7 +17,7 @@ RUN dnf -y install 'dnf-command(copr)' && \
 # We enable updates-testing to pull in the latest annobin
 RUN dnf install -y --enablerepo=updates-testing \
     rpminspect-${RPMINSPECT_VERSION} \
-    rpminspect-data-fedora-${RPMINSPECT_DATA_VERSION} \
+    rpminspect-data-fedora \
     libabigail \
     clamav-update \
     python3-pyyaml \

--- a/rpminspect_runner.sh
+++ b/rpminspect_runner.sh
@@ -148,6 +148,9 @@ if [ ! -f "${results_cached_file}" ]; then
     #     We can uncomment this once the latest annocheck can be installed from a stable repo.
     #dnf update -y annobin* 2>&1 > update_annobin.log || :
 
+    # Update the data package
+    dnf update -y rpminspect-data* 2>&1 > update_rpminspect_data.log || :
+
     # Run all inspections and cache results
     /usr/bin/rpminspect -c ${config} \
             ${debug:+-v} \


### PR DESCRIPTION
Newer data package shouldn't break CI. So it should be safe to update it
before running rpminspect.