### PR TITLE
Return 3 when no test results were found

### DIFF
--- a/rpminspect_runner.sh
+++ b/rpminspect_runner.sh
@@ -77,7 +77,9 @@ print('yes', end='') if is_enabled else print('no', end='')" "effective_rpminspe
     if [ "${is_enabled}" == "no" ]; then
         echo
         echo "This inspection is disabled."
-        exit 0
+
+        # in tmt, this means "no test results found"
+        exit 3
     fi
 }
 


### PR DESCRIPTION
We should not return 0 (success) when an inspection is disabled.