### PR TITLE
Install rpminspect from OSCI COPR repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV RPMINSPECT_PACKAGE_NAME=rpminspect
 ENV RPMINSPECT_DATA_PACKAGE_NAME=rpminspect-data-fedora
 
 RUN dnf -y install 'dnf5-command(copr)' && \
-    dnf -y copr enable dcantrell/rpminspect && \
+    dnf -y copr enable @osci/rpminspect && \
     dnf -y copr enable @osci/fedora-license-data && \
     dnf copr enable @osci/libabigail
 


### PR DESCRIPTION
It seems like the version in the upstream COPR is broken atm.