### PR TITLE
Get build ID from tagBuild task

### DIFF
--- a/rpminspect_runner.sh
+++ b/rpminspect_runner.sh
@@ -103,7 +103,7 @@ get_task_info() {
     build_nvr=$(basename "$(echo "$task_info" | grep "SRPM: " | head -1 | awk '{ print $2 }' | sed 's|\.src.rpm$||g')")
     if [ -z "$build_nvr" ]; then
       # Imported Konflux builds don't have SRPM tasks
-      build_nvr=$(echo "$task_info" | grep "Build: " | head -1 | awk '{ print $2 }')
+      build_nvr=$(echo "$task_info" | grep "Build: " | tail -1 | awk '{ print $2 }')
     fi
     is_scratch="no"
     is_scratch_output=$(echo "$task_info" | grep "scratch: True")


### PR DESCRIPTION
It happened that when the task 70732186 ended, there were 2 associated builds:
```
$ brew list-builds --task=70732186
Build                                                    Built by          State
-------------------------------------------------------  ----------------  ----------------
buildah-1.39.9-1.el9_6,draft_4011515                     osci-distrobuildsync  BUILDING
buildah-1.39.9-1.el9_6,draft_4011563                     osci-distrobuildsync  COMPLETE
```

It caused https://artifacts.osci.redhat.com/testing-farm/3572c274-291f-4096-87a5-608ec37e2ef9/
```
rpminspect: *** Koji build state is building for buildah-1.39.9-1.el9_6,draft_4011515, cannot continue
rpminspect: *** unable to find build buildah-1.39.9-1.el9_6,draft_4011515 in Koji hub https://brewhub.engineering.redhat.com/brewhub
```

The [4011515](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=4011515) was in some limbo state until it was automatically canceled more than a day later.
We don't want that one, we want the [4011563](https://brewweb.engineering.redhat.com/brew/buildinfo?buildID=4011563).

```
$ brew taskinfo -v -r 70732186 | grep "Build: "
Build: buildah-1.39.9-1.el9_6,draft_4011515 (4011515)
    Build: buildah-1.39.9-1.el9_6,draft_4011563
```

In the command output, the first line is from the `build` task.
It says the build ID is `4011515`, until the `4011515` is canceled later,
in which case it changes to the `4011563`.

The second line is from the `tagBuild` task.
It says `4011563` all the time, so we can take that one instead.

BTW, it broke also installability; the fix is https://github.com/fedora-ci/mini-tps/pull/106