### PR TITLE
Use dcantrell copr repo for rpminspect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV RPMINSPECT_PACKAGE_NAME=rpminspect
 ENV RPMINSPECT_DATA_PACKAGE_NAME=rpminspect-data-fedora
 
 RUN dnf -y install 'dnf5-command(copr)' && \
-    dnf -y copr enable @osci/rpminspect && \
+    dnf -y copr enable dcantrell/rpminspect && \
     dnf -y copr enable @osci/fedora-license-data && \
     dnf copr enable @osci/libabigail
 


### PR DESCRIPTION
That repo gets newer builds on every fix to rpminspect, as oppsoed to the @osci/rpminspect repo which hasn't seen a fix in months.

Hopefully pulling that in will get us fixes for issues like this that are breaking the Fedora pipeline compeltely for me: https://github.com/rpminspect/rpminspect/issues/1576

In terms of stability, the dcantrell repo is used by RHEL pipelines too. If it's stable enough for RHEL, it should be stable enough for Fedora.